### PR TITLE
Feature: 점주 및 유저 로그인 설정

### DIFF
--- a/src/main/java/quickbites/qubit/config/CorsConfig.java
+++ b/src/main/java/quickbites/qubit/config/CorsConfig.java
@@ -1,0 +1,31 @@
+package quickbites.qubit.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.cors.CorsConfigurationSource;
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    @Primary
+    public CorsConfigurationSource corsConfiguration(){
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.SET_COOKIE));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setMaxAge(3600L);
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/quickbites/qubit/config/WebSecurityConfig.java
+++ b/src/main/java/quickbites/qubit/config/WebSecurityConfig.java
@@ -1,21 +1,56 @@
 package quickbites.qubit.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+import quickbites.qubit.domain.security.filter.FormLoginFilter;
+import quickbites.qubit.global.util.jwt.JwtUtil;
 
 @Configuration
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class WebSecurityConfig{
+
+    private final CorsConfigurationSource corsConfigurationSource;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .formLogin(FormLoginConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                .addFilterAt(new FormLoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, objectMapper), UsernamePasswordAuthenticationFilter.class)
+
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeHttpRequest ->{
                     authorizeHttpRequest
                             .requestMatchers("/test/**").permitAll();
@@ -23,7 +58,7 @@ public class WebSecurityConfig{
 
 
                     authorizeHttpRequest
-                            .anyRequest().authenticated();
+                            .anyRequest().permitAll();
 
 
                 });

--- a/src/main/java/quickbites/qubit/domain/admin/entity/Admin.java
+++ b/src/main/java/quickbites/qubit/domain/admin/entity/Admin.java
@@ -1,10 +1,10 @@
-package quickbites.qubit.domain.Admin;
+package quickbites.qubit.domain.admin.entity;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import quickbites.qubit.domain.User.Role;
+import quickbites.qubit.domain.user.entity.Role;
 
 import java.util.UUID;
 

--- a/src/main/java/quickbites/qubit/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/quickbites/qubit/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,9 @@
+package quickbites.qubit.domain.admin.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.admin.entity.Admin;
+
+import java.util.UUID;
+
+public interface AdminRepository extends JpaRepository<Admin, UUID> {
+}

--- a/src/main/java/quickbites/qubit/domain/guest/entity/Guest.java
+++ b/src/main/java/quickbites/qubit/domain/guest/entity/Guest.java
@@ -1,0 +1,32 @@
+package quickbites.qubit.domain.guest.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import quickbites.qubit.domain.user.entity.Role;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Guest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    UUID id;
+
+    String name;
+    String telephoneNumber;
+    String password;
+
+    @Enumerated(EnumType.STRING)
+    Role role;
+
+    @Builder
+    public Guest(String telephoneNumber, String password, String name) {
+        this.telephoneNumber = telephoneNumber;
+        this.password = password;
+        this.name = name;
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/guest/repository/GuestRepository.java
+++ b/src/main/java/quickbites/qubit/domain/guest/repository/GuestRepository.java
@@ -1,0 +1,11 @@
+package quickbites.qubit.domain.guest.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.guest.entity.Guest;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GuestRepository extends JpaRepository<Guest, UUID> {
+    Optional<Guest> findByTelephoneNumber(String telephoneNumber);
+}

--- a/src/main/java/quickbites/qubit/domain/menu/entity/Menu.java
+++ b/src/main/java/quickbites/qubit/domain/menu/entity/Menu.java
@@ -1,14 +1,13 @@
-package quickbites.qubit.domain.Menu;
+package quickbites.qubit.domain.menu.entity;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import quickbites.qubit.domain.OrderMenu.OrderMenu;
-import quickbites.qubit.domain.Store.Store;
+import quickbites.qubit.domain.ordermenu.entity.OrderMenu;
+import quickbites.qubit.domain.store.entity.Store;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -16,8 +15,8 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class Menu {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
 
     private String name;    // 메뉴명
     private int price;  // 메뉴 가격

--- a/src/main/java/quickbites/qubit/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/quickbites/qubit/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,8 @@
+package quickbites.qubit.domain.menu.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.menu.entity.Menu;
+
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/quickbites/qubit/domain/order/entity/Order.java
+++ b/src/main/java/quickbites/qubit/domain/order/entity/Order.java
@@ -1,10 +1,10 @@
-package quickbites.qubit.domain.Order;
+package quickbites.qubit.domain.order.entity;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import quickbites.qubit.domain.OrderMenu.OrderMenu;
-import quickbites.qubit.domain.Store.Store;
+import quickbites.qubit.domain.ordermenu.entity.OrderMenu;
+import quickbites.qubit.domain.store.entity.Store;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/quickbites/qubit/domain/order/entity/OrderStatus.java
+++ b/src/main/java/quickbites/qubit/domain/order/entity/OrderStatus.java
@@ -1,4 +1,4 @@
-package quickbites.qubit.domain.Order;
+package quickbites.qubit.domain.order.entity;
 
 public enum OrderStatus {
     WAITING, COMPLETED, CANCEL

--- a/src/main/java/quickbites/qubit/domain/order/repository/OrderRepository.java
+++ b/src/main/java/quickbites/qubit/domain/order/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package quickbites.qubit.domain.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.order.entity.Order;
+
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+}

--- a/src/main/java/quickbites/qubit/domain/ordermenu/entity/OrderMenu.java
+++ b/src/main/java/quickbites/qubit/domain/ordermenu/entity/OrderMenu.java
@@ -1,12 +1,12 @@
-package quickbites.qubit.domain.OrderMenu;
+package quickbites.qubit.domain.ordermenu.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import quickbites.qubit.domain.Menu.Menu;
-import quickbites.qubit.domain.Order.Order;
+import quickbites.qubit.domain.menu.entity.Menu;
+import quickbites.qubit.domain.order.entity.Order;
 
 import java.util.UUID;
 

--- a/src/main/java/quickbites/qubit/domain/ordermenu/repository/OrderMenuRepository.java
+++ b/src/main/java/quickbites/qubit/domain/ordermenu/repository/OrderMenuRepository.java
@@ -1,0 +1,9 @@
+package quickbites.qubit.domain.ordermenu.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.ordermenu.entity.OrderMenu;
+
+import java.util.UUID;
+
+public interface OrderMenuRepository extends JpaRepository<OrderMenu, UUID> {
+}

--- a/src/main/java/quickbites/qubit/domain/owner/entity/Owner.java
+++ b/src/main/java/quickbites/qubit/domain/owner/entity/Owner.java
@@ -1,11 +1,11 @@
-package quickbites.qubit.domain.Owner;
+package quickbites.qubit.domain.owner.entity;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import quickbites.qubit.domain.Store.Store;
-import quickbites.qubit.domain.User.Role;
+import quickbites.qubit.domain.store.entity.Store;
+import quickbites.qubit.domain.user.entity.Role;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +21,8 @@ public class Owner {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    private String ownerId;
+    private String password;
     private String name;
     private String telephoneNumber;
 

--- a/src/main/java/quickbites/qubit/domain/owner/repository/OwnerRepository.java
+++ b/src/main/java/quickbites/qubit/domain/owner/repository/OwnerRepository.java
@@ -1,0 +1,11 @@
+package quickbites.qubit.domain.owner.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.owner.entity.Owner;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OwnerRepository extends JpaRepository<Owner, UUID> {
+    Optional<Owner> findByOwnerId(String OwnerId);
+}

--- a/src/main/java/quickbites/qubit/domain/security/dto/AdminDetails.java
+++ b/src/main/java/quickbites/qubit/domain/security/dto/AdminDetails.java
@@ -1,0 +1,44 @@
+package quickbites.qubit.domain.security.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import quickbites.qubit.domain.admin.entity.Admin;
+import quickbites.qubit.domain.user.entity.Role;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class AdminDetails implements CustomUserDetails{
+    private Admin admin;
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+        authorities.add(new SimpleGrantedAuthority(admin.getRole().getValue()));
+        return authorities;
+    }
+
+    @Override
+    public String getId() {
+        return admin.getId().toString();
+    }
+
+    @Override
+    public boolean hasRole(Role role) {
+        return role.equals(admin.getRole());
+    }
+
+    @Override
+    public String getPassword() {
+        return admin.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return admin.getAdminId();
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/security/dto/AppUserDetails.java
+++ b/src/main/java/quickbites/qubit/domain/security/dto/AppUserDetails.java
@@ -1,0 +1,44 @@
+package quickbites.qubit.domain.security.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import quickbites.qubit.domain.user.entity.Role;
+import quickbites.qubit.domain.user.entity.User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class AppUserDetails implements CustomUserDetails{
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+        authorities.add(new SimpleGrantedAuthority(user.getRole().getValue()));
+        return authorities;
+    }
+
+    @Override
+    public String getId() {
+        return user.getId().toString();
+    }
+
+    @Override
+    public boolean hasRole(Role role) {
+        return role.equals(user.getRole());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/security/dto/CustomUserDetails.java
+++ b/src/main/java/quickbites/qubit/domain/security/dto/CustomUserDetails.java
@@ -1,0 +1,21 @@
+package quickbites.qubit.domain.security.dto;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import quickbites.qubit.domain.user.entity.Role;
+import quickbites.qubit.global.exception.CustomException;
+import quickbites.qubit.global.response.error.ErrorType;
+
+public interface CustomUserDetails extends UserDetails {
+    String getId();
+
+    boolean hasRole(Role role);
+
+    default String getSingleAuthority() {
+        return getAuthorities()
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .findFirst()
+                .orElseThrow(()-> new CustomException(ErrorType.ROLE_NOT_FOUND));
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/security/dto/GuestDetails.java
+++ b/src/main/java/quickbites/qubit/domain/security/dto/GuestDetails.java
@@ -1,0 +1,43 @@
+package quickbites.qubit.domain.security.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import quickbites.qubit.domain.guest.entity.Guest;
+import quickbites.qubit.domain.user.entity.Role;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class GuestDetails implements CustomUserDetails{
+
+    private final Guest guest;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(guest.getRole().getValue()));
+        return authorities;
+    }
+
+    @Override
+    public String getId() {
+        return guest.getId().toString();
+    }
+
+    @Override
+    public boolean hasRole(Role role) {
+        return role.equals(Role.USER_GUEST);
+    }
+
+    @Override
+    public String getPassword() {
+        return guest.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return guest.getTelephoneNumber(); // 따로 게스트 번호를 넣든지 해야할수도?
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/security/dto/OwnerDetails.java
+++ b/src/main/java/quickbites/qubit/domain/security/dto/OwnerDetails.java
@@ -1,0 +1,45 @@
+package quickbites.qubit.domain.security.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import quickbites.qubit.domain.owner.entity.Owner;
+import quickbites.qubit.domain.user.entity.Role;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class OwnerDetails implements CustomUserDetails {
+
+    private final Owner owner;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+        authorities.add(new SimpleGrantedAuthority(owner.getRole().getValue()));
+        return authorities;
+    }
+
+
+    @Override
+    public String getId() {
+        return owner.getId().toString();
+    }
+
+    @Override
+    public boolean hasRole(Role role) {
+        return role.equals(owner.getRole());
+    }
+
+    @Override
+    public String getPassword() {
+        return owner.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return owner.getOwnerId();
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/security/filter/FormLoginFilter.java
+++ b/src/main/java/quickbites/qubit/domain/security/filter/FormLoginFilter.java
@@ -1,0 +1,89 @@
+package quickbites.qubit.domain.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StreamUtils;
+import quickbites.qubit.domain.security.dto.CustomUserDetails;
+import quickbites.qubit.global.response.error.ErrorRes;
+import quickbites.qubit.global.response.error.ErrorType;
+import quickbites.qubit.global.util.jwt.JwtUtil;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class FormLoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            String requestBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+            Map<String, String> loginInfo = objectMapper.readValue(requestBody, Map.class);
+
+            String role = loginInfo.get("role");
+            String id = loginInfo.get("id");
+            String password = loginInfo.get("password");
+
+            String username = role + " " + id;
+
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password);
+
+            return authenticationManager.authenticate(authToken);
+
+        } catch (IOException e) {
+            log.error("error message : " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        CustomUserDetails userDetails = (CustomUserDetails) authResult.getPrincipal();
+        String role = userDetails.getSingleAuthority();
+        String id = userDetails.getId();
+
+        String accessToken = jwtUtil.generateAccessToken(id, role);
+        String refreshToken = jwtUtil.generateRefreshToken(id, role);
+
+        response.setHeader("Authorization", accessToken);
+        response.addCookie(createCookie("refreshToken", refreshToken));
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().write("Good");
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        ErrorType error = ErrorType.LOGIN_FAILED;
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType("application/json; charset=utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorRes.of(error.getStatusCode(), error.getMessage())));
+    }
+
+    private Cookie createCookie(String key, String value){
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*24*14); // = refresh token expiration
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/security/service/MyAppUserDetailsService.java
+++ b/src/main/java/quickbites/qubit/domain/security/service/MyAppUserDetailsService.java
@@ -1,0 +1,58 @@
+package quickbites.qubit.domain.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import quickbites.qubit.domain.guest.entity.Guest;
+import quickbites.qubit.domain.guest.repository.GuestRepository;
+import quickbites.qubit.domain.owner.entity.Owner;
+import quickbites.qubit.domain.owner.repository.OwnerRepository;
+import quickbites.qubit.domain.security.dto.AppUserDetails;
+import quickbites.qubit.domain.security.dto.GuestDetails;
+import quickbites.qubit.domain.security.dto.OwnerDetails;
+import quickbites.qubit.domain.user.entity.User;
+import quickbites.qubit.domain.user.repository.UserRepository;
+import quickbites.qubit.global.exception.CustomException;
+import quickbites.qubit.global.response.error.ErrorType;
+
+
+@Service
+@RequiredArgsConstructor
+public class MyAppUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final GuestRepository guestRepository;
+    private final OwnerRepository ownerRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        String role = username.split(" ")[0];
+        String id = username.split(" ")[1];
+
+        switch (role) {
+            case "USER" -> {
+                User user = userRepository.findByUserId(id)
+                        .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+                return new AppUserDetails(user);
+            }
+            case "USER_GUEST" -> {
+                Guest guest = guestRepository.findByTelephoneNumber(id)
+                        .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+                return new GuestDetails(guest);
+            }
+            case "OWNER" -> {
+
+                Owner owner = ownerRepository.findByOwnerId(id)
+                        .orElseThrow(() -> new CustomException(ErrorType.OWNER_NOT_FOUND));
+
+                return new OwnerDetails(owner);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/store/entity/Store.java
+++ b/src/main/java/quickbites/qubit/domain/store/entity/Store.java
@@ -1,10 +1,9 @@
-package quickbites.qubit.domain.Store;
+package quickbites.qubit.domain.store.entity;
 
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
-import quickbites.qubit.domain.Menu.Menu;
-import quickbites.qubit.domain.Order.Order;
-import quickbites.qubit.domain.Owner.Owner;
+import quickbites.qubit.domain.menu.entity.Menu;
+import quickbites.qubit.domain.owner.entity.Owner;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/quickbites/qubit/domain/store/repository/StoreRepository.java
+++ b/src/main/java/quickbites/qubit/domain/store/repository/StoreRepository.java
@@ -1,0 +1,9 @@
+package quickbites.qubit.domain.store.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.store.entity.Store;
+
+import java.util.UUID;
+
+public interface StoreRepository extends JpaRepository<Store, UUID> {
+}

--- a/src/main/java/quickbites/qubit/domain/user/entity/Role.java
+++ b/src/main/java/quickbites/qubit/domain/user/entity/Role.java
@@ -1,4 +1,4 @@
-package quickbites.qubit.domain.User;
+package quickbites.qubit.domain.user.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/quickbites/qubit/domain/user/entity/User.java
+++ b/src/main/java/quickbites/qubit/domain/user/entity/User.java
@@ -1,4 +1,4 @@
-package quickbites.qubit.domain.User;
+package quickbites.qubit.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -19,17 +19,18 @@ public class User {
 
     private String name;
 
-    private String providerUserInfo;
-
+    //private String providerUserInfo;
+    private String userId;
     @Enumerated(EnumType.STRING)
     private Role role;
 
     private String email;
 
     @Builder
-    public User(String name, String provider, String providerId, String email) {
+    public User(String name, String userId, String email) {
         this.name = name;
-        this.providerUserInfo = provider + " " + providerId;
+        this.userId = userId;
+        //this.providerUserInfo = provider + " " + providerId;
         this.email = email;
         this.role = Role.USER;
     }

--- a/src/main/java/quickbites/qubit/domain/user/repository/UserRepository.java
+++ b/src/main/java/quickbites/qubit/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package quickbites.qubit.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import quickbites.qubit.domain.user.entity.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByUserId(String userId);
+}

--- a/src/main/java/quickbites/qubit/global/response/error/ErrorType.java
+++ b/src/main/java/quickbites/qubit/global/response/error/ErrorType.java
@@ -11,6 +11,7 @@ public enum ErrorType {
     // 인증
     // 401
     UN_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증이 실패되었습니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패입니다."),
 
     // 인가
     // 403
@@ -18,7 +19,8 @@ public enum ErrorType {
 
     //데이터
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터 입니다."),
-
+    ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "역할이 존재하지 않습니다."),
+    OWNER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않은 점주 입니다."),
     // 서버 에러
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 서버 팀으로 연락주시기 바랍니다.");

--- a/src/main/java/quickbites/qubit/global/util/jwt/JwtUtil.java
+++ b/src/main/java/quickbites/qubit/global/util/jwt/JwtUtil.java
@@ -4,7 +4,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import quickbites.qubit.domain.User.Role;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -30,7 +29,7 @@ public class JwtUtil {
         this.issuer = issuer;
     }
 
-    public String generateAccessToken(String userId, Role role){
+    public String generateAccessToken(String userId, String role){
         return Jwts.builder()
                 .subject(userId)
                 .issuedAt(new Date())
@@ -42,7 +41,7 @@ public class JwtUtil {
                 .compact();
     }
 
-    public String generateRefreshToken(String userId, Role role){
+    public String generateRefreshToken(String userId, String role){
         return Jwts.builder()
                 .subject(userId)
                 .issuedAt(new Date())

--- a/src/test/java/quickbites/qubit/jwt/JwtTest.java
+++ b/src/test/java/quickbites/qubit/jwt/JwtTest.java
@@ -2,7 +2,7 @@ package quickbites.qubit.jwt;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import quickbites.qubit.domain.User.Role;
+import quickbites.qubit.domain.user.entity.Role;
 import quickbites.qubit.global.util.jwt.JwtUtil;
 
 import javax.crypto.spec.SecretKeySpec;
@@ -30,8 +30,8 @@ public class JwtTest {
     @Test
     void generateTokenTest(){
 
-        String accessToken = jwtUtil.generateAccessToken("hello", Role.USER);
-        String refreshToken = jwtUtil.generateRefreshToken("hello", Role.USER);
+        String accessToken = jwtUtil.generateAccessToken("hello", Role.USER.toString());
+        String refreshToken = jwtUtil.generateRefreshToken("hello", Role.USER.toString());
         System.out.println("token = " + accessToken);
         System.out.println("refreshToken = " + refreshToken);
     }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #5 
- 점주, 유저, 게스트 로그인 기능 필요에 따른 로그인 필터 필요
- 각 역할에 따른 userDetails , userDetailsService 필요
- 커스텀 로그인 추가에 따른 WebSecurityConfig 설정 

## 추가 및 변경사항
- Guest 엔티티 추가 작성
- 각 엔티티 별 repository 추가
- 역할에 따른 userDetails 및 userDetailsService 추가
- WebSecurityConfig 필터 및 필요한 설정 추가
- 로그인 및 데이터 없는 경우에 필요한 에러타입 추가


## 📌 기타
- 추후에 회원가입 기능 추가하면서 로그인 기능까지 테스트 예정!
