### PR TITLE
Feature: 회원가입 기능 및 로그인 테스트

### DIFF
--- a/src/main/java/quickbites/qubit/config/CorsConfig.java
+++ b/src/main/java/quickbites/qubit/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig {
     @Primary
     public CorsConfigurationSource corsConfiguration(){
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.addAllowedOriginPattern("*"); // 테스트 과정에서는 모든 도메인 허용.
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.SET_COOKIE));
         configuration.setAllowedHeaders(List.of("*"));

--- a/src/main/java/quickbites/qubit/domain/auth/controller/AuthController.java
+++ b/src/main/java/quickbites/qubit/domain/auth/controller/AuthController.java
@@ -1,0 +1,34 @@
+package quickbites.qubit.domain.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import quickbites.qubit.domain.auth.dto.GuestSignupReq;
+import quickbites.qubit.domain.auth.dto.OwnerSignupReq;
+import quickbites.qubit.domain.auth.service.AuthService;
+import quickbites.qubit.global.response.success.SuccessRes;
+import quickbites.qubit.global.response.success.SuccessType;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/signup/guest")
+    public ResponseEntity<?> signup(@RequestBody GuestSignupReq guestSignupReq) {
+        authService.signupForGuest(guestSignupReq);
+        return ResponseEntity
+                .status(SuccessType.OK.getStatus())
+                .body(SuccessRes.from(SuccessType.OK));
+    }
+
+    @PostMapping("/signup/owner")
+    public ResponseEntity<?> signup(@RequestBody OwnerSignupReq ownerSignupReq) {
+        authService.signupForOwner(ownerSignupReq);
+        return ResponseEntity
+                .status(SuccessType.OK.getStatus())
+                .body(SuccessRes.from(SuccessType.OK));
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/auth/dto/GuestSignupReq.java
+++ b/src/main/java/quickbites/qubit/domain/auth/dto/GuestSignupReq.java
@@ -1,0 +1,21 @@
+package quickbites.qubit.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import quickbites.qubit.domain.guest.entity.Guest;
+import quickbites.qubit.domain.user.entity.Role;
+
+@Getter
+@NoArgsConstructor
+public class GuestSignupReq extends SignupReq{
+
+
+    public static Guest toEntity(GuestSignupReq guestSignupReq, String encodedPassword) {
+        return Guest.builder()
+                .name(guestSignupReq.getName())
+                .telephoneNumber(guestSignupReq.getTelephoneNumber())
+                .password(encodedPassword)
+                .role(Role.USER_GUEST)
+                .build();
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/auth/dto/OwnerSignupReq.java
+++ b/src/main/java/quickbites/qubit/domain/auth/dto/OwnerSignupReq.java
@@ -1,0 +1,25 @@
+package quickbites.qubit.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import quickbites.qubit.domain.owner.entity.Owner;
+import quickbites.qubit.domain.user.entity.Role;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OwnerSignupReq extends SignupReq{
+    private String ownerId;
+
+
+    public static Owner toEntity(OwnerSignupReq ownerSignupReq, String encodedPassword) {
+        return Owner.builder()
+                .ownerId(ownerSignupReq.getOwnerId())
+                .name(ownerSignupReq.getName())
+                .telephoneNumber(ownerSignupReq.getTelephoneNumber())
+                .password(encodedPassword)
+                .role(Role.OWNER)
+                .build();
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/auth/dto/SignupReq.java
+++ b/src/main/java/quickbites/qubit/domain/auth/dto/SignupReq.java
@@ -1,0 +1,14 @@
+package quickbites.qubit.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupReq {
+    private String name;
+    private String telephoneNumber;
+    private String password;
+}

--- a/src/main/java/quickbites/qubit/domain/auth/service/AuthService.java
+++ b/src/main/java/quickbites/qubit/domain/auth/service/AuthService.java
@@ -1,0 +1,36 @@
+package quickbites.qubit.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.RestController;
+import quickbites.qubit.domain.auth.dto.GuestSignupReq;
+import quickbites.qubit.domain.auth.dto.OwnerSignupReq;
+import quickbites.qubit.domain.guest.entity.Guest;
+import quickbites.qubit.domain.guest.repository.GuestRepository;
+import quickbites.qubit.domain.owner.entity.Owner;
+import quickbites.qubit.domain.owner.repository.OwnerRepository;
+import quickbites.qubit.global.exception.CustomException;
+import quickbites.qubit.global.response.error.ErrorType;
+
+
+@RestController
+@RequiredArgsConstructor
+public class AuthService {
+    private final GuestRepository guestRepository;
+    private final OwnerRepository ownerRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public void signupForGuest(GuestSignupReq guestSignupReq) {
+        if(guestRepository.existsByName(guestSignupReq.getName()))
+            throw new CustomException(ErrorType.ALREADY_EXISTS_GUEST);
+        Guest guest = GuestSignupReq.toEntity(guestSignupReq, bCryptPasswordEncoder.encode(guestSignupReq.getPassword()));
+        guestRepository.save(guest);
+    }
+
+    public void signupForOwner(OwnerSignupReq ownerSignupReq) {
+        if(ownerRepository.existsByOwnerId(ownerSignupReq.getOwnerId()))
+            throw new CustomException(ErrorType.ALREADY_EXISTS_Owner);
+        Owner owner = OwnerSignupReq.toEntity(ownerSignupReq, bCryptPasswordEncoder.encode(ownerSignupReq.getPassword()));
+        ownerRepository.save(owner);
+    }
+}

--- a/src/main/java/quickbites/qubit/domain/guest/entity/Guest.java
+++ b/src/main/java/quickbites/qubit/domain/guest/entity/Guest.java
@@ -24,9 +24,15 @@ public class Guest {
     Role role;
 
     @Builder
-    public Guest(String telephoneNumber, String password, String name) {
+    public Guest(
+            String telephoneNumber,
+            String password,
+            String name,
+            Role role
+    ) {
         this.telephoneNumber = telephoneNumber;
         this.password = password;
         this.name = name;
+        this.role = role;
     }
 }

--- a/src/main/java/quickbites/qubit/domain/guest/repository/GuestRepository.java
+++ b/src/main/java/quickbites/qubit/domain/guest/repository/GuestRepository.java
@@ -8,4 +8,7 @@ import java.util.UUID;
 
 public interface GuestRepository extends JpaRepository<Guest, UUID> {
     Optional<Guest> findByTelephoneNumber(String telephoneNumber);
+    Optional<Guest> findByName(String name);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/quickbites/qubit/domain/owner/entity/Owner.java
+++ b/src/main/java/quickbites/qubit/domain/owner/entity/Owner.java
@@ -33,8 +33,17 @@ public class Owner {
     Role role;
 
     @Builder
-    public Owner(String name, String telephoneNumber) {
+    public Owner(
+            String ownerId,
+            String password,
+            String name,
+            String telephoneNumber,
+            Role role
+            ) {
+        this.ownerId = ownerId;
+        this.password = password;
         this.name = name;
         this.telephoneNumber = telephoneNumber;
+        this.role = role;
     }
 }

--- a/src/main/java/quickbites/qubit/domain/owner/repository/OwnerRepository.java
+++ b/src/main/java/quickbites/qubit/domain/owner/repository/OwnerRepository.java
@@ -8,4 +8,6 @@ import java.util.UUID;
 
 public interface OwnerRepository extends JpaRepository<Owner, UUID> {
     Optional<Owner> findByOwnerId(String OwnerId);
+    boolean existsByOwnerId(String ownerId);
+
 }

--- a/src/main/java/quickbites/qubit/domain/security/service/MyAppUserDetailsService.java
+++ b/src/main/java/quickbites/qubit/domain/security/service/MyAppUserDetailsService.java
@@ -39,7 +39,7 @@ public class MyAppUserDetailsService implements UserDetailsService {
                 return new AppUserDetails(user);
             }
             case "USER_GUEST" -> {
-                Guest guest = guestRepository.findByTelephoneNumber(id)
+                Guest guest = guestRepository.findByName(id)
                         .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
 
                 return new GuestDetails(guest);

--- a/src/main/java/quickbites/qubit/domain/user/entity/User.java
+++ b/src/main/java/quickbites/qubit/domain/user/entity/User.java
@@ -21,17 +21,25 @@ public class User {
 
     //private String providerUserInfo;
     private String userId;
+
+    private String email;
+    private String telephoneNumber;
+
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    private String email;
-
     @Builder
-    public User(String name, String userId, String email) {
+    public User(
+            String name,
+            String userId,
+            String email,
+            String telephoneNumber
+            ) {
         this.name = name;
         this.userId = userId;
         //this.providerUserInfo = provider + " " + providerId;
         this.email = email;
+        this.telephoneNumber = telephoneNumber;
         this.role = Role.USER;
     }
 

--- a/src/main/java/quickbites/qubit/global/response/error/ErrorType.java
+++ b/src/main/java/quickbites/qubit/global/response/error/ErrorType.java
@@ -21,6 +21,12 @@ public enum ErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터 입니다."),
     ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "역할이 존재하지 않습니다."),
     OWNER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않은 점주 입니다."),
+
+    //데이터 충돌
+    ALREADY_EXISTS_GUEST(HttpStatus.CONFLICT, "이미 존재하는 게스트입니다."),
+    ALREADY_EXISTS_Owner(HttpStatus.CONFLICT, "이미 존재하는 점주입니다."),
+
+
     // 서버 에러
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 서버 팀으로 연락주시기 바랍니다.");

--- a/src/main/java/quickbites/qubit/global/response/success/SuccessRes.java
+++ b/src/main/java/quickbites/qubit/global/response/success/SuccessRes.java
@@ -1,0 +1,14 @@
+package quickbites.qubit.global.response.success;
+
+public record SuccessRes<T>(
+        int status,
+        String message,
+        T data
+){
+    public static SuccessRes<?> from(SuccessType success){
+        return new SuccessRes<>(success.getStatusCode(), success.getMessage(), null);
+    }
+    public static <T> SuccessRes<T> of(SuccessType success, T data) {
+        return new SuccessRes<T>(success.getStatusCode(), success.getMessage(), data);
+    }
+}

--- a/src/main/java/quickbites/qubit/global/response/success/SuccessType.java
+++ b/src/main/java/quickbites/qubit/global/response/success/SuccessType.java
@@ -1,0 +1,20 @@
+package quickbites.qubit.global.response.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessType {
+
+    //200
+    OK(HttpStatus.OK, "요청이 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    public int getStatusCode(){
+        return status.value();
+    }
+}

--- a/src/main/java/quickbites/qubit/global/util/jwt/JwtUtil.java
+++ b/src/main/java/quickbites/qubit/global/util/jwt/JwtUtil.java
@@ -18,12 +18,12 @@ public class JwtUtil {
     private final String issuer;
 
     public JwtUtil(
-            @Value("${JWT_SECRET_KEY)")SecretKey secretKey,
-            @Value("${JWT_ACCESS_EXPIRATION")Duration accessTokenDuration,
-            @Value("${JWT_REFRESH_EXPIRATION")Duration refreshTokenDuration,
+            @Value("${JWT_SECRET_KEY}") String secretKey,
+            @Value("${JWT_ACCESS_EXPIRATION}")Duration accessTokenDuration,
+            @Value("${JWT_REFRESH_EXPIRATION}")Duration refreshTokenDuration,
             @Value("${JWT_ISSUER}") String issuer
     ){
-        this.secretKey = new SecretKeySpec(secretKey.getEncoded(), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.secretKey = new SecretKeySpec(secretKey.getBytes(), Jwts.SIG.HS256.key().build().getAlgorithm());
         this.accessTokenDuration = accessTokenDuration;
         this.refreshTokenDuration = refreshTokenDuration;
         this.issuer = issuer;

--- a/src/test/java/quickbites/qubit/jwt/JwtTest.java
+++ b/src/test/java/quickbites/qubit/jwt/JwtTest.java
@@ -1,5 +1,6 @@
 package quickbites.qubit.jwt;
 
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import quickbites.qubit.domain.user.entity.Role;
@@ -17,10 +18,10 @@ public class JwtTest {
 
     @BeforeEach
     void setup() {
-        byte[] keyBytes = "GjCU1g8/AbJhSzj4McaCKa7Amu+Fz1N4w8jJfZanEIk=".getBytes(); // 테스트용 키
+        String secretKey = "GjCU1g8/AbJhSzj4McaCKa7Amu+Fz1N4w8jJfZanEIk="; // 테스트용 키
 
         jwtUtil = new JwtUtil(
-                new SecretKeySpec(keyBytes, "HmacSHA256"),
+                secretKey,
                 Duration.ofDays(10000),
                 Duration.ofDays(7),
                 "issuer"


### PR DESCRIPTION
## 작업 동기 및 이슈
- #7 

## 추가 및 변경사항
- 회원가입 기능 추가 (owner, guest)
- AuthController, AuthService 및 관련 dto 작성
- 엔티티 필드 추가 및 삭제

## 테스트 결과

### 회원가입(점주)
<img width="600" src="https://github.com/user-attachments/assets/2092c08f-4dd6-4ca3-9447-14fe38692a7a" />

### 회원가입(게스트)
<img width="600" src="https://github.com/user-attachments/assets/facb087a-9688-4b2f-b026-b9fe65c02622" />

### 로그인기능 테스트
<img width="600" src="https://github.com/user-attachments/assets/93d62358-1a3a-412e-a8f1-f88f892ffe6c" />
<img width="600" src="https://github.com/user-attachments/assets/b5f38493-48d5-4335-a30a-b94d961e7bab" />


## 📌 기타
- 추가적으로 로그인 될 때 토큰 redis 저장되는 기능 추가해야한다.